### PR TITLE
cypress specPattern fixed

### DIFF
--- a/template/cypress.config.ts
+++ b/template/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
 	video: false,
 	e2e: {
 		baseUrl: "http://localhost:3000",
-		specPattern: "tests/e2e/tests/**/*.spec.{js,jsx,ts,tsx}",
+		specPattern: "tests/e2e/e2e/**/*.spec.{js,jsx,ts,tsx}",
 		screenshotOnRunFailure: false,
 		video: false,
 		viewportWidth: 1920,


### PR DESCRIPTION
Hey,

I've just downloaded your template and it seems there exists a misconfiguration in cypress.config.ts file.

If you try to execute cypress, you'll receive following error:

```ps
> cypress run

Missing baseUrl in compilerOptions. tsconfig-paths will be skipped
Can't run because no spec files were found.

We searched for specs matching this glob pattern:

  > C:\Workroot\project1\tests\e2e\tests\**\*.spec.{js,jsx,ts,tsx}
```

2 months ago you had a commit like 'refactor: move cypress test to test/e2e folder' and I think is the origin of the problem. 

```js
import { defineConfig } from "cypress";

export default defineConfig({
	video: false,
	e2e: {
		baseUrl: "http://localhost:3000",
		specPattern: "tests/e2e/tests/**/*.spec.{js,jsx,ts,tsx}", // <-- Either path or folder name must be different. tests/e2e/tests doesn't exist.
		screenshotOnRunFailure: false,
		video: false,
		viewportWidth: 1920,
		viewportHeight: 1080,
		supportFile: "tests/e2e/support/e2e.ts",
	},
});
```

Taking into account that old commit, I have decided to adapt cypress.config.ts file instead of rename test folder, but in my humble opinion, having two e2e folders in a row is a little bit strange.



